### PR TITLE
Set correct userAgent identifier and currency type

### DIFF
--- a/lib/src/models/responses/source.dart
+++ b/lib/src/models/responses/source.dart
@@ -1,6 +1,7 @@
 import 'package:omise_dart/src/enums/absorption_type.dart';
 import 'package:omise_dart/src/enums/bank.dart';
 import 'package:omise_dart/src/enums/charge_status.dart';
+import 'package:omise_dart/src/enums/currency.dart';
 import 'package:omise_dart/src/enums/payment_method_name.dart';
 import 'package:omise_dart/src/models/requests/create_source_request.dart';
 import 'package:omise_dart/src/models/responses/base_response.dart';
@@ -14,7 +15,7 @@ class Source extends BaseResponse {
   final BillingAddress? billing;
   final ChargeStatus chargeStatus;
   final DateTime createdAt;
-  final String currency;
+  final Currency currency;
   final List? discounts;
   final String? email;
   final String flow;
@@ -87,7 +88,7 @@ class Source extends BaseResponse {
           : null,
       chargeStatus: ChargeStatusExtension.fromString(json['charge_status']),
       createdAt: DateTime.parse(json['created_at']),
-      currency: json['currency'],
+      currency: CurrencyExtension.fromString(json['currency']),
       discounts: json['discounts'] != null ? (json['discounts'] as List) : null,
       email: json['email'],
       flow: json['flow'],
@@ -132,7 +133,7 @@ class Source extends BaseResponse {
       'billing': billing?.toJson(),
       'charge_status': chargeStatus.name,
       'created_at': createdAt.toIso8601StringWithoutMilliseconds(),
-      'currency': currency,
+      'currency': currency.value,
       'discounts': discounts,
       'email': email,
       'flow': flow,

--- a/lib/src/omise_http_client.dart
+++ b/lib/src/omise_http_client.dart
@@ -89,8 +89,8 @@ class OmiseHttpClient {
       return userAgent!;
     }
     final sdkVersion = PackageInfo.packageVersion;
-    final packageName = PackageInfo.packageName;
-    return 'dart/${Platform.version} $packageName/$sdkVersion (${Platform.operatingSystem} ${Platform.operatingSystemVersion})';
+    final userAgentIdentifier = PackageInfo.userAgentIdentifier;
+    return 'dart/${Platform.version} $userAgentIdentifier/$sdkVersion (${Platform.operatingSystem} ${Platform.operatingSystemVersion})';
   }
 
   /// Returns the HTTP headers required for Omise API requests.

--- a/lib/src/package_info.dart
+++ b/lib/src/package_info.dart
@@ -12,4 +12,6 @@ class PackageInfo {
   ///
   /// This constant holds the package's version as defined in `pubspec.yaml`.
   static const String packageVersion = '0.2.0';
+
+  static const String userAgentIdentifier = "OmiseDart";
 }

--- a/test/models/responses/source_test.dart
+++ b/test/models/responses/source_test.dart
@@ -1,6 +1,7 @@
-import 'package:omise_dart/omise_dart.dart';
 import 'package:omise_dart/src/enums/absorption_type.dart';
+import 'package:omise_dart/src/enums/bank.dart';
 import 'package:omise_dart/src/enums/charge_status.dart';
+import 'package:omise_dart/src/enums/currency.dart';
 import 'package:omise_dart/src/enums/payment_method_name.dart';
 import 'package:omise_dart/src/extensions/date_time_no_milliseconds.dart';
 import 'package:omise_dart/src/models/responses/source.dart';
@@ -18,7 +19,7 @@ void main() {
         amount: 1000,
         chargeStatus: ChargeStatus.pending,
         createdAt: createdAt,
-        currency: 'THB',
+        currency: Currency.thb,
         flow: 'redirect',
         type: PaymentMethodName.promptpay,
         absorptionType: AbsorptionType.customer,
@@ -45,7 +46,7 @@ void main() {
       expect(sourceFromJson.amount, 1000);
       expect(sourceFromJson.chargeStatus, ChargeStatus.pending);
       expect(sourceFromJson.createdAt, createdAt);
-      expect(sourceFromJson.currency, 'THB');
+      expect(sourceFromJson.currency, Currency.thb);
       expect(sourceFromJson.flow, 'redirect');
       expect(sourceFromJson.type, PaymentMethodName.promptpay);
       expect(sourceFromJson.absorptionType, AbsorptionType.customer);

--- a/test/package_info_test.dart
+++ b/test/package_info_test.dart
@@ -7,6 +7,10 @@ void main() {
       expect(PackageInfo.packageName, 'omise_dart');
     });
 
+    test('should return correct userAgentIdentifier', () {
+      expect(PackageInfo.userAgentIdentifier, 'OmiseDart');
+    });
+
     test('should return correct package version', () {
       expect(PackageInfo.packageVersion, '0.2.0');
     });


### PR DESCRIPTION
## Description

- Set userAgent to `omiseDart` instead of `omise_dart` for consistency across packages.
- Set `currency` param to `Currency` type instead of string