### PR TITLE
Block skey in frontend

### DIFF
--- a/lib/src/dart_flutter.dart
+++ b/lib/src/dart_flutter.dart
@@ -1,0 +1,18 @@
+/// A constant that indicates whether the code is running in a pure Dart environment.
+///
+/// Similar to Flutter's [kIsWeb](https://api.flutter.dev/flutter/foundation/kIsWeb-constant.html),
+/// which determines if the app is running on the web, `kIsPureDart` is used to check if the
+/// environment is purely Dart, such as when running in a Dart console application or in a
+/// server-side context.
+///
+/// Use this variable to handle logic specific to non-Flutter or server-side Dart environments.
+///
+/// Example:
+/// ```dart
+/// if (kIsPureDart) {
+///   print("Running in a pure Dart environment.");
+/// } else {
+///   print("Running in a Flutter environment.");
+/// }
+/// ```
+const kIsPureDart = false;

--- a/lib/src/dart_pure.dart
+++ b/lib/src/dart_pure.dart
@@ -1,0 +1,18 @@
+/// A constant that indicates whether the code is running in a pure Dart environment.
+///
+/// Similar to Flutter's [kIsWeb](https://api.flutter.dev/flutter/foundation/kIsWeb-constant.html),
+/// which determines if the app is running on the web, `kIsPureDart` is used to check if the
+/// environment is purely Dart, such as when running in a Dart console application or in a
+/// server-side context.
+///
+/// Use this variable to handle logic specific to non-Flutter or server-side Dart environments.
+///
+/// Example:
+/// ```dart
+/// if (kIsPureDart) {
+///   print("Running in a pure Dart environment.");
+/// } else {
+///   print("Running in a Flutter environment.");
+/// }
+/// ```
+const kIsPureDart = true;

--- a/lib/src/enums/omise_api_errors.dart
+++ b/lib/src/enums/omise_api_errors.dart
@@ -4,7 +4,9 @@ enum OmiseApiErrors {
   unableToGetToken(message: "Unable to get token"),
   unableToGetCapability(message: "Unable to get capability"),
   unableToCreateSource(message: "Unable to create source"),
-  unableToGetSource(message: "Unable to get source");
+  unableToGetSource(message: "Unable to get source"),
+  secretKeyMustNotBeUsedInFrontendEnvironments(
+      message: 'Secret key must not be used in frontend environments');
 
   final String message;
 

--- a/lib/src/services/omise_api.dart
+++ b/lib/src/services/omise_api.dart
@@ -2,6 +2,7 @@ import 'package:omise_dart/src/omise_http_client.dart';
 import 'package:omise_dart/src/services/capability_api.dart';
 import 'package:omise_dart/src/services/sources_api.dart';
 import 'package:omise_dart/src/services/tokens_api.dart';
+import 'package:omise_dart/src/utils.dart';
 
 /// A main entry point for interacting with the Omise API.
 ///
@@ -32,6 +33,9 @@ class OmiseApi {
     bool? ignoreNullKeys,
     String? userAgent,
   }) {
+    if (secretKey != null) {
+      Utils.isFrontEndEnvironment();
+    }
     // Create the HTTP client using the provided parameters
     final OmiseHttpClient omiseHttpClient = OmiseHttpClient(
       publicKey: publicKey,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,4 +1,7 @@
 import 'dart:convert';
+import 'dart_pure.dart' if (dart.library.ui) 'dart_flutter.dart';
+import 'package:omise_dart/src/enums/omise_api_errors.dart';
+import 'package:omise_dart/src/exceptions/omise_api_exception.dart';
 
 /// A utility class that provides various helper functions for the application.
 class Utils {
@@ -9,5 +12,13 @@ class Utils {
 
     // Create the auth header value
     return encodedKey;
+  }
+
+  static void isFrontEndEnvironment() {
+    if (!kIsPureDart) {
+      throw OmiseApiException(
+          message: OmiseApiErrors
+              .secretKeyMustNotBeUsedInFrontendEnvironments.message);
+    }
   }
 }


### PR DESCRIPTION
## Description
Add a restriction that prevents the usage of `skey` in frontend applications.
A conditional import is used to determine if the environment is pure dart or not as we do not have access to flutter implementations in the omise-dart library.
