### PR TITLE
Support apple pay merchantId field

### DIFF
--- a/lib/src/models/requests/create_source_request.dart
+++ b/lib/src/models/requests/create_source_request.dart
@@ -178,20 +178,20 @@ class ShippingAddress {
 }
 
 class Item {
-  int? amount;
-  String? sku;
-  String? name;
-  int? quantity;
+  int amount;
+  String sku;
+  String name;
+  int quantity;
   String? category;
   String? brand;
   String? itemUri;
   String? imageUri;
 
   Item({
-    this.amount,
-    this.sku,
-    this.name,
-    this.quantity,
+    required this.amount,
+    required this.sku,
+    required this.name,
+    required this.quantity,
     this.category,
     this.brand,
     this.itemUri,

--- a/lib/src/models/requests/create_token_request.dart
+++ b/lib/src/models/requests/create_token_request.dart
@@ -19,6 +19,7 @@ class CreateTokenRequest {
   // Google Pay / Apple Pay Fields
   TokenizationMethod? method; // "googlepay" or "applepay"
   String? data; // Tokenized payment data
+  String? merchantId;
   String? billingName;
   String? billingCity;
   String? billingCountry;
@@ -46,6 +47,7 @@ class CreateTokenRequest {
 
     // Google Pay / Apple Pay parameters
     this.method,
+    this.merchantId,
     this.data,
     this.billingName,
     this.billingCity,
@@ -73,6 +75,7 @@ class CreateTokenRequest {
       street1: json['street1'],
       street2: json['street2'],
       method: TokenizationMethodExtension.fromString(json['method']),
+      merchantId: json['merchant_id'],
       data: json['data'],
       billingName: json['billing_name'],
       billingCity: json['billing_city'],
@@ -101,6 +104,7 @@ class CreateTokenRequest {
       'street1': street1,
       'street2': street2,
       'method': method?.value,
+      'merchant_id': merchantId,
       'data': data,
       'billing_name': billingName,
       'billing_city': billingCity,

--- a/lib/src/models/requests/create_token_request.dart
+++ b/lib/src/models/requests/create_token_request.dart
@@ -28,6 +28,7 @@ class CreateTokenRequest {
   String? billingStreet1;
   String? billingStreet2;
   String? billingPhoneNumber;
+  String? brand;
 
   CreateTokenRequest({
     // Card payment parameters
@@ -57,6 +58,7 @@ class CreateTokenRequest {
     this.billingStreet1,
     this.billingStreet2,
     this.billingPhoneNumber,
+    this.brand,
   });
 
   factory CreateTokenRequest.fromJson(Map<String, dynamic> json) {
@@ -85,6 +87,7 @@ class CreateTokenRequest {
       billingStreet1: json['billing_street1'],
       billingStreet2: json['billing_street2'],
       billingPhoneNumber: json['billing_phone_number'],
+      brand: json['brand'],
     );
   }
 
@@ -114,6 +117,7 @@ class CreateTokenRequest {
       'billing_street1': billingStreet1,
       'billing_street2': billingStreet2,
       'billing_phone_number': billingPhoneNumber,
+      'brand': brand,
     };
   }
 }


### PR DESCRIPTION
## Description

- Add `merchantId` field to support apple pay in token request.
- Make item params required in source request when using the item field.