### PR TITLE
Add dynamic environment access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # required for SonarCloud
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2

--- a/lib/omise_dart.dart
+++ b/lib/omise_dart.dart
@@ -19,3 +19,4 @@ export 'src/exceptions/omise_api_exception.dart';
 export 'src/enums/authorization_type.dart';
 export 'src/enums/dispute_status.dart';
 export 'src/enums/absorption_type.dart';
+export 'src/enums/environment.dart';

--- a/lib/src/enums/environment.dart
+++ b/lib/src/enums/environment.dart
@@ -7,7 +7,7 @@ enum Environment {
       case Environment.production:
         return 'https://api.omise.co';
       case Environment.staging:
-        return String.fromEnvironment('BASE_STAGING_URL');
+        return const String.fromEnvironment('BASE_STAGING_URL');
     }
   }
 
@@ -16,7 +16,7 @@ enum Environment {
       case Environment.production:
         return 'https://vault.omise.co';
       case Environment.staging:
-        return String.fromEnvironment('BASE_STAGING_VAULT_URL');
+        return const String.fromEnvironment('BASE_STAGING_VAULT_URL');
     }
   }
 }

--- a/lib/src/enums/environment.dart
+++ b/lib/src/enums/environment.dart
@@ -1,8 +1,31 @@
 enum Environment {
-  baseUrl(value: "https://api.omise.co"),
-  baseVaultUrl(value: "https://vault.omise.co");
+  production,
+  staging;
 
-  final String value;
+  String getBaseUrl() {
+    switch (this) {
+      case Environment.production:
+        return 'https://api.omise.co';
+      case Environment.staging:
+        return String.fromEnvironment('BASE_STAGING_URL');
+    }
+  }
 
-  const Environment({required this.value});
+  String getBaseVaultUrl() {
+    switch (this) {
+      case Environment.production:
+        return 'https://vault.omise.co';
+      case Environment.staging:
+        return String.fromEnvironment('BASE_STAGING_VAULT_URL');
+    }
+  }
+}
+
+extension EnvironmentExtension on Environment {
+  static Environment fromString(String? environment) {
+    return Environment.values.firstWhere(
+      (type) => type.name.toLowerCase() == environment?.toLowerCase(),
+      orElse: () => Environment.production,
+    );
+  }
 }

--- a/lib/src/omise_http_client.dart
+++ b/lib/src/omise_http_client.dart
@@ -30,6 +30,7 @@ class OmiseHttpClient {
     http.Client? httpClient,
     this.enableDebug = false,
     this.ignoreNullKeys = true,
+    this.environment,
   }) : _httpClient = httpClient ?? http.Client() {
     if ([null, true].contains(publicKey?.isEmpty) &&
         [null, true].contains(secretKey?.isEmpty)) {
@@ -41,9 +42,6 @@ class OmiseHttpClient {
 
   /// For testing purposes and passing custom client
   final http.Client _httpClient;
-
-  /// The base URL for the Omise API.
-  String baseUrl = Environment.baseUrl.value;
 
   /// The version of the Omise API to use.
   final String apiVersion = "2019-05-29";
@@ -63,11 +61,15 @@ class OmiseHttpClient {
   /// Wether to send keys with null values in the request body or not
   final bool? ignoreNullKeys;
 
+  // The api environment to be used.
+  final Environment? environment;
+
   String getBaseUrl(String path) {
+    final env = environment ?? Environment.production;
     if (path.contains('token')) {
-      return Environment.baseVaultUrl.value;
+      return env.getBaseVaultUrl();
     }
-    return Environment.baseUrl.value;
+    return env.getBaseUrl();
   }
 
   /// Retrieves a user agent string that includes the Dart SDK version, the SDK package information,

--- a/lib/src/services/omise_api.dart
+++ b/lib/src/services/omise_api.dart
@@ -1,3 +1,4 @@
+import 'package:omise_dart/src/enums/environment.dart';
 import 'package:omise_dart/src/omise_http_client.dart';
 import 'package:omise_dart/src/services/capability_api.dart';
 import 'package:omise_dart/src/services/charges_api.dart';
@@ -19,6 +20,7 @@ class OmiseApi {
   /// - [enableDebug]: A boolean to enable debug logging (optional).
   /// - [ignoreNullKeys]: A boolean to ignore null values when sending API requests (optional).
   /// - [userAgent]: A custom user agent string to identify the client (optional).
+  /// - [environment]: The api environment to be used (optional).
   ///
   /// These parameters are passed to the [OmiseHttpClient], which is used by
   /// [TokensApi] for making HTTP requests.
@@ -33,6 +35,7 @@ class OmiseApi {
     bool? enableDebug,
     bool? ignoreNullKeys,
     String? userAgent,
+    Environment? environment,
   }) {
     if (secretKey != null) {
       Utils.isFrontEndEnvironment();
@@ -44,6 +47,7 @@ class OmiseApi {
       enableDebug: enableDebug,
       ignoreNullKeys: ignoreNullKeys,
       userAgent: userAgent,
+      environment: environment,
     );
 
     // Initialize the APIs

--- a/test/enums/environment_test.dart
+++ b/test/enums/environment_test.dart
@@ -1,0 +1,48 @@
+import 'package:test/test.dart';
+import 'package:omise_dart/src/enums/environment.dart';
+
+void main() {
+  group('EnvironmentExtension', () {
+    test('fromString should return the correct Environment for valid strings',
+        () {
+      expect(EnvironmentExtension.fromString('production'),
+          Environment.production);
+      expect(EnvironmentExtension.fromString('staging'), Environment.staging);
+    });
+
+    test('fromString should be case insensitive', () {
+      expect(EnvironmentExtension.fromString('Production'),
+          Environment.production);
+      expect(EnvironmentExtension.fromString('STAGING'), Environment.staging);
+    });
+
+    test('fromString should return production for invalid strings', () {
+      expect(
+          EnvironmentExtension.fromString('invalid'), Environment.production);
+      expect(EnvironmentExtension.fromString(null), Environment.production);
+      expect(EnvironmentExtension.fromString(''), Environment.production);
+    });
+  });
+
+  group('Environment base URLs', () {
+    test('getBaseUrl should return correct URL for production', () {
+      expect(Environment.production.getBaseUrl(), 'https://api.omise.co');
+    });
+
+    test('getBaseVaultUrl should return correct URL for production', () {
+      expect(
+          Environment.production.getBaseVaultUrl(), 'https://vault.omise.co');
+    });
+
+    test('getBaseUrl and getBaseVaultUrl for staging should use env variables',
+        () {
+      // In test environment, you can't override the envs used as in dart its read only, this will just increase the code coverage but the value of the envs will always be empty.
+      // Also adding the actual envs into the test command does not work as its not supported
+      const baseStagingUrl = String.fromEnvironment('BASE_STAGING_URL');
+      const baseStagingVaultUrl =
+          String.fromEnvironment('BASE_STAGING_VAULT_URL');
+      expect(Environment.staging.getBaseUrl(), baseStagingUrl);
+      expect(Environment.staging.getBaseVaultUrl(), baseStagingVaultUrl);
+    });
+  });
+}

--- a/test/omise_http_client_test.dart
+++ b/test/omise_http_client_test.dart
@@ -9,7 +9,7 @@ import 'package:omise_dart/src/exceptions/omise_api_exception.dart';
 
 void main() {
   group('OmiseHttpClient Tests', () {
-    final baseUrl = Environment.baseUrl.value;
+    final baseUrl = Environment.production.getBaseUrl();
     late MockClient mockClient;
     late OmiseHttpClient omiseHttpClient;
 


### PR DESCRIPTION
## Description

Allow passing the desired api env in order to be able to switch smoothly between envs and allow dynamic env injection when using the flutter bridge to native integrations.